### PR TITLE
Add Docker setup for ThreadX STM32H750 demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/build/
+*.o
+*.elf
+*.bin
+*.hex
+
+# Docker stuff
+threadx/
+stm32h7xx_hal_driver/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.15)
+project(ThreadX_UART5_Hello C)
+
+set(CMAKE_C_STANDARD 11)
+
+# Path to ThreadX
+set(THREADX_ROOT ${THREADX_ROOT} CACHE PATH "Path to ThreadX")
+# Path to HAL drivers
+set(HAL_DRIVER_DIR ${HAL_DRIVER_DIR} CACHE PATH "Path to STM32 HAL driver")
+
+# Include ThreadX build system
+add_subdirectory(${THREADX_ROOT} threadx_build)
+
+include_directories(
+    ${THREADX_ROOT}/common/inc
+    ${HAL_DRIVER_DIR}/Inc
+    ${HAL_DRIVER_DIR}/Inc/Legacy
+)
+
+add_executable(hello_uart5
+    src/main.c
+)
+
+target_link_libraries(hello_uart5 PRIVATE tx)
+
+# Optional: Link HAL sources as needed
+# target_sources(hello_uart5 PRIVATE
+#     ${HAL_DRIVER_DIR}/Src/stm32h7xx_hal_uart.c
+#     ...
+# )

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build git gcc-arm-none-eabi gdb-multiarch \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Clone ThreadX and HAL drivers
+RUN git clone --depth 1 https://github.com/eclipse-threadx/threadx.git && \
+    git clone --depth 1 https://github.com/STMicroelectronics/stm32h7xx_hal_driver.git
+
+# Copy project
+COPY . /workspace/project
+WORKDIR /workspace/project
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # ThreadX_STM32H750XBHx
-Use ThreadX to customize ALL-IO-INTERFACE transfer all data to I2C2 port with max performance
+
+This repository demonstrates how to build a minimal ThreadX application for the STM32H750XBHx MCU using a Docker based build environment. The example configures UART5 (pins PB12/PB13) and prints `Hello world` once the kernel is running.
+
+## Prerequisites
+- Docker installed on the host machine
+
+## Build Steps
+The provided `Dockerfile` sets up an Ubuntu container with the Arm GNU toolchain, CMake and Ninja. It also clones the official ThreadX sources and the STM32H7 HAL drivers.
+
+1. Build the Docker image:
+   ```bash
+   docker build -t threadx-h750 .
+   ```
+2. Run the container and build the example inside:
+   ```bash
+   docker run --rm -it threadx-h750 ./build.sh
+   ```
+   The resulting ELF binary will be located in the `build/` directory.
+
+## Source Overview
+- `src/main.c` – minimal ThreadX application that initializes UART5 and prints `Hello world`.
+- `CMakeLists.txt` – uses the CMake files from ThreadX to build the demo.
+- `build.sh` – helper script executed inside the container.
+
+This setup follows the [ThreadX development guidelines](https://github.com/eclipse-threadx/threadx) by building ThreadX as part of the application using CMake and the Arm GNU Toolchain.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Default directories
+THREADX_DIR=${THREADX_DIR:-/workspace/threadx}
+HAL_DIR=${HAL_DIR:-/workspace/stm32h7xx_hal_driver}
+BUILD_DIR=build
+
+cmake -B$BUILD_DIR -GNinja \
+    -DCMAKE_TOOLCHAIN_FILE=${THREADX_DIR}/cmake/cortex_m7.cmake \
+    -DTHREADX_ROOT=${THREADX_DIR} \
+    -DHAL_DRIVER_DIR=${HAL_DIR} \
+    .
+
+cmake --build $BUILD_DIR

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,56 @@
+#include "tx_api.h"
+#include "stm32h7xx_hal.h"
+#include <stdio.h>
+
+UART_HandleTypeDef huart5;
+
+void SystemClock_Config(void);
+static void MX_USART5_UART_Init(void);
+
+void tx_application_define(void *first_unused_memory)
+{
+    (void)first_unused_memory;
+    /* Send hello world once threadX is running */
+    const char msg[] = "Hello world\r\n";
+    HAL_UART_Transmit(&huart5, (uint8_t*)msg, sizeof(msg) - 1, HAL_MAX_DELAY);
+    while(1) { tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND); }
+}
+
+int main(void)
+{
+    HAL_Init();
+    SystemClock_Config();
+    MX_USART5_UART_Init();
+
+    tx_kernel_enter();
+}
+
+void SystemClock_Config(void)
+{
+    /* Placeholder: configure HCLK and PCLK. Actual implementation depends on board. */
+}
+
+static void MX_USART5_UART_Init(void)
+{
+    __HAL_RCC_USART5_CLK_ENABLE();
+    huart5.Instance = USART5;
+    huart5.Init.BaudRate = 115200;
+    huart5.Init.WordLength = UART_WORDLENGTH_8B;
+    huart5.Init.StopBits = UART_STOPBITS_1;
+    huart5.Init.Parity = UART_PARITY_NONE;
+    huart5.Init.Mode = UART_MODE_TX_RX;
+    huart5.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+    huart5.Init.OverSampling = UART_OVERSAMPLING_16;
+    huart5.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+    huart5.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
+    HAL_UART_Init(&huart5);
+}
+
+int _write(int fd, char *ptr, int len)
+{
+    if (fd == 1 || fd == 2) {
+        HAL_UART_Transmit(&huart5, (uint8_t*)ptr, len, HAL_MAX_DELAY);
+        return len;
+    }
+    return -1;
+}


### PR DESCRIPTION
## Summary
- add Dockerfile with Arm toolchain and ThreadX/HAL sources
- provide build.sh script and CMake project
- implement minimal UART5 "Hello world" example using ThreadX
- document build steps in README

## Testing
- `bash build.sh` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2641d2648329a02c64d0efbc22b8