### PR TITLE
Add STM32H750 startup and flash linker script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.elf
 *.bin
 *.hex
+build.log
 
 # Docker stuff
 threadx/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(ThreadX_UART5_Hello C)
+project(ThreadX_UART5_Hello C ASM)
 
 set(CMAKE_C_STANDARD 11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(hello_uart5
     src/main.c
     src/tx_initialize_low_level.c
     src/usart.c
+    startup_stm32h750xb.S
 )
 
 target_compile_definitions(hello_uart5 PRIVATE STM32H750xx)
@@ -40,6 +41,11 @@ target_sources(hello_uart5 PRIVATE ${HAL_SOURCES})
 target_sources(hello_uart5 PRIVATE ${CMSIS_SYSTEM_SRC})
 
 target_link_libraries(hello_uart5 PRIVATE threadx)
+
+target_link_options(hello_uart5 PRIVATE
+    -T${CMAKE_CURRENT_SOURCE_DIR}/stm32h750xb_flash.ld
+    -Wl,-Map=hello_uart5.map
+)
 
 target_sources(hello_uart5 PRIVATE
     ${HAL_DRIVER_DIR}/Src/stm32h7xx_hal_uart.c

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: all clean
+
+all:
+	./build.sh
+
+clean:
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ The provided `Dockerfile` sets up an Ubuntu container with the Arm GNU toolchain
    ```
 2. Run the container and build the example inside:
    ```bash
-    docker run -it threadx-h750 --name threadx-h750-docker -p 2022:22 bash
-    ```
-    The resulting ELF binary will be located in the `build/` directory.
+   docker run -it threadx-h750 --name threadx-h750-docker -p 2022:22 bash
+   ```
+   Inside the container you can simply run `make` to build the project.
+   The resulting ELF binary will be located in the `build/` directory.
+
+3. To remove generated build files run:
+   ```bash
+   make clean
+   ```
 
 ## Flashing the application
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ The provided `Dockerfile` sets up an Ubuntu container with the Arm GNU toolchain
    ```
 2. Run the container and build the example inside:
    ```bash
-   docker run -it threadx-h750 --name threadx-h750-docker -p 2022:22 bash
-   ```
-   The resulting ELF binary will be located in the `build/` directory.
+    docker run -it threadx-h750 --name threadx-h750-docker -p 2022:22 bash
+    ```
+    The resulting ELF binary will be located in the `build/` directory.
+
+## Flashing the application
+
+The project now includes a startup file and linker script so the
+application is linked for flash address `0x08000000`. Use STM32CubeProgrammer
+or a similar tool to load `build/hello_uart5.elf` onto the board.
 
 ## Source Overview
 - `src/main.c` – minimal ThreadX application that initializes UART5 and prints `Hello world`.

--- a/startup_stm32h750xb.S
+++ b/startup_stm32h750xb.S
@@ -1,0 +1,89 @@
+.syntax unified
+.cpu cortex-m7
+.fpu fpv5-d16
+.thumb
+
+.global g_pfnVectors
+.global Reset_Handler
+
+.extern SystemInit
+.extern main
+
+/* Vector table */
+.section .isr_vector,"a",%progbits
+.type g_pfnVectors, %object
+g_pfnVectors:
+    .word _estack
+    .word Reset_Handler
+    /* Core handlers */
+    .word NMI_Handler
+    .word HardFault_Handler
+    .word MemManage_Handler
+    .word BusFault_Handler
+    .word UsageFault_Handler
+    .word 0
+    .word 0
+    .word 0
+    .word 0
+    .word SVC_Handler
+    .word DebugMon_Handler
+    .word 0
+    .word PendSV_Handler
+    .word SysTick_Handler
+    /* Device specific interrupts - all point to Default_Handler */
+    .rept 240-16
+    .word Default_Handler
+    .endr
+
+/* Reset handler */
+.section .text.Reset_Handler,"ax",%progbits
+.type Reset_Handler, %function
+Reset_Handler:
+    ldr r0, =_estack
+    mov sp, r0
+    /* Copy data from flash to RAM */
+    ldr r0, =_sdata
+    ldr r1, =_etext
+    ldr r2, =_edata
+1:
+    cmp r0, r2
+    bge 2f
+    ldr r3, [r1], #4
+    str r3, [r0], #4
+    b 1b
+2:
+    /* Zero BSS */
+    ldr r0, =_sbss
+    ldr r1, =_ebss
+    mov r2, #0
+3:
+    cmp r0, r1
+    bge 4f
+    str r2, [r0], #4
+    b 3b
+4:
+    bl SystemInit
+    bl main
+    b .
+
+.size Reset_Handler, .-Reset_Handler
+
+/* Default handler */
+.section .text.Default_Handler,"ax",%progbits
+.type Default_Handler, %function
+Default_Handler:
+    b .
+.size Default_Handler, .-Default_Handler
+
+/* Dummy handlers for core exceptions */
+.section .text.Handlers,"ax",%progbits
+NMI_Handler:           b .
+HardFault_Handler:     b .
+MemManage_Handler:     b .
+BusFault_Handler:      b .
+UsageFault_Handler:    b .
+SVC_Handler:           b .
+DebugMon_Handler:      b .
+PendSV_Handler:        b .
+SysTick_Handler:       b .
+

--- a/stm32h750xb_flash.ld
+++ b/stm32h750xb_flash.ld
@@ -1,0 +1,45 @@
+/* Linker script for STM32H750XBHx */
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 128K
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+  .isr_vector :
+  {
+    KEEP(*(.isr_vector))
+  } >FLASH
+
+  .text :
+  {
+    *(.text*)
+    *(.rodata*)
+    KEEP(*(.init))
+    KEEP(*(.fini))
+    _etext = .;
+  } >FLASH
+
+  .data : AT(_etext)
+  {
+    _sdata = .;
+    *(.data*)
+    _edata = .;
+  } >RAM
+
+  .bss :
+  {
+    _sbss = .;
+    *(.bss*)
+    *(COMMON)
+    _ebss = .;
+  } >RAM
+
+  /DISCARD/ : { *(.note*) *(.comment*) }
+}
+


### PR DESCRIPTION
## Summary
- add startup assembly file for STM32H750
- add linker script mapping code to flash at 0x08000000
- hook startup file and linker script into the CMake build
- document flashing in README
- ignore build log

## Testing
- `./build.sh` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_686f4e7dc3808329a11b2e8e35b31f07