### PR TITLE
Add I2C hub skeleton

### DIFF
--- a/Inc/i2c_hub.h
+++ b/Inc/i2c_hub.h
@@ -1,0 +1,6 @@
+#ifndef I2C_HUB_H
+#define I2C_HUB_H
+
+void hub_start(void);
+
+#endif // I2C_HUB_H

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ or a similar tool to load `build/hello_uart5.elf` onto the board.
 - `build.sh` – helper script executed inside the container.
 
 This setup follows the [ThreadX development guidelines](https://github.com/eclipse-threadx/threadx) by building ThreadX as part of the application using CMake and the Arm GNU Toolchain.
+
+## Advanced Communication Hub Example
+
+For a conceptual design of turning the STM32H750XBHx into an I2C-based communication hub that controls other peripherals (UART, SPI, GPIO, PWM, ADC, CAN) using ThreadX message queues, see [docs/communication_hub.md](docs/communication_hub.md).
+This document links to a small C skeleton showing how the threads and queues fit together.

--- a/docs/communication_hub.md
+++ b/docs/communication_hub.md
@@ -1,0 +1,73 @@
+# I2C Communication Hub Example for STM32H750XBHx
+
+This document sketches an approach for turning the STM32H750XBHx into an I/O communication hub accessible via I2C. The microcontroller acts as an I2C slave with address `0x36` (decimal `54`) and interprets incoming messages that request operations on other peripherals (UART, SPI, GPIO, PWM, ADC, CAN). Results are returned to the I2C master using a simple structured format such as JSON or MessagePack.
+
+## Overview
+1. **I2C Slave Interface**
+   - Configure `I2C1` (or another instance) in slave mode.
+   - Set the own address to `0x36`.
+   - Incoming frames are parsed into commands specifying which peripheral to access and what operation to perform.
+
+2. **ThreadX Tasks**
+   - Create a dedicated ThreadX thread for I2C handling. This thread receives commands from the master and posts them to a FIFO message queue.
+   - Spawn separate threads for each peripheral type (UART, SPI, GPIO, PWM, ADC, CAN). These threads wait on the queue for commands addressed to them.
+   - Each peripheral thread performs the requested operation and enqueues the response payload for the I2C thread to transmit back to the master.
+
+3. **Message Format**
+   - Use a lightweight structured format. MessagePack (`umsgpack`) works well, though simple JSON is also possible.
+   - A command might contain fields such as `"target"` (e.g. `"UART"`, `"SPI"`), `"operation"` (read/write), and `"data"`.
+   - Responses mirror the same structure and can contain a status field and any returned data.
+
+4. **FIFO and Synchronization**
+   - A single ThreadX queue (or multiple queues per peripheral) ensures commands are processed in order and prevents data loss.
+   - Mutexes or semaphores guard shared resources if needed (for example, if multiple commands attempt to access the same SPI bus).
+
+## Example Flow
+1. I2C master sends a packet requesting a UART transmission.
+2. The I2C thread parses the packet and posts a message to the UART thread's queue.
+3. The UART thread sends the data out over UART and posts a completion response back to the I2C thread.
+4. The I2C thread packages the response (e.g., `{ "status": "ok" }`) and writes it onto the I2C bus for the master to read.
+
+Using ThreadX threads and message queues keeps each peripheral handler independent while avoiding contention on shared resources. Expanding the command set allows the hub to expose many MCU features over a single I2C interface.
+
+## Example Command Format
+
+A simple JSON request from the master might resemble:
+
+```json
+{ "target": "GPIO", "operation": "read", "pin": 7 }
+```
+
+The corresponding response would be:
+
+```json
+{ "status": "ok", "data": 1 }
+```
+
+## Pseudocode Outline
+
+Below is a very small sketch of how the threads could be organized:
+
+```c
+void i2c_thread(void *arg) {
+    for (;;) {
+        command_t cmd = read_from_i2c();
+        tx_queue_send(&command_queue, &cmd, TX_WAIT_FOREVER);
+    }
+}
+
+void peripheral_thread(void *arg) {
+    for (;;) {
+        command_t cmd;
+        tx_queue_receive(&command_queue, &cmd, TX_WAIT_FOREVER);
+        response_t rsp = handle_command(&cmd);
+        tx_queue_send(&response_queue, &rsp, TX_WAIT_FOREVER);
+    }
+}
+```
+
+The I2C thread would also be responsible for sending `response_t` objects back to the master.
+
+## Reference Implementation
+
+A minimal C skeleton showing the ThreadX threads and queues is provided in [src/i2c_hub.c](../src/i2c_hub.c). It illustrates how an I2C thread forwards commands to peripheral threads using `TX_QUEUE`.

--- a/src/i2c_hub.c
+++ b/src/i2c_hub.c
@@ -1,0 +1,87 @@
+// Example skeleton implementing an I2C communication hub
+// using ThreadX threads and queues. This is not complete
+// production code but demonstrates how the peripherals
+// could be structured.
+
+#include "tx_api.h"
+#include "stm32h7xx_hal.h"
+#include "i2c.h"      // HAL I2C handle
+#include "usart.h"
+#include <string.h>
+
+#define HUB_I2C_ADDR 0x36
+#define QUEUE_LEN    8
+
+typedef struct {
+    uint8_t target;      // e.g. enum for UART/SPI/GPIO
+    uint8_t operation;   // read/write
+    uint8_t data[16];    // example payload
+} hub_cmd_t;
+
+typedef struct {
+    uint8_t status;
+    uint8_t data[16];
+} hub_rsp_t;
+
+static TX_QUEUE cmd_queue;
+static TX_QUEUE rsp_queue;
+static TX_THREAD i2c_thread;
+static TX_THREAD uart_thread;
+
+static VOID i2c_thread_entry(ULONG arg);
+static VOID uart_thread_entry(ULONG arg);
+
+void hub_start(void)
+{
+    static UCHAR cmd_queue_buf[QUEUE_LEN * sizeof(hub_cmd_t)];
+    static UCHAR rsp_queue_buf[QUEUE_LEN * sizeof(hub_rsp_t)];
+    static UCHAR i2c_stack[1024];
+    static UCHAR uart_stack[1024];
+
+    tx_queue_create(&cmd_queue, "cmd_queue", TX_1_ULONG, cmd_queue_buf,
+                    sizeof(cmd_queue_buf));
+    tx_queue_create(&rsp_queue, "rsp_queue", TX_1_ULONG, rsp_queue_buf,
+                    sizeof(rsp_queue_buf));
+
+    tx_thread_create(&i2c_thread, "i2c_thread", i2c_thread_entry, 0,
+                     i2c_stack, sizeof(i2c_stack), 5, 5,
+                     TX_NO_TIME_SLICE, TX_AUTO_START);
+
+    tx_thread_create(&uart_thread, "uart_thread", uart_thread_entry, 0,
+                     uart_stack, sizeof(uart_stack), 5, 5,
+                     TX_NO_TIME_SLICE, TX_AUTO_START);
+}
+
+static VOID i2c_thread_entry(ULONG arg)
+{
+    (void)arg;
+    for (;;) {
+        hub_cmd_t cmd;
+        // Receive command frame over I2C in slave mode
+        HAL_I2C_Slave_Receive(&hi2c1, (uint8_t *)&cmd, sizeof(cmd), HAL_MAX_DELAY);
+        tx_queue_send(&cmd_queue, &cmd, TX_WAIT_FOREVER);
+
+        hub_rsp_t rsp;
+        tx_queue_receive(&rsp_queue, &rsp, TX_WAIT_FOREVER);
+        // Send response back to master
+        HAL_I2C_Slave_Transmit(&hi2c1, (uint8_t *)&rsp, sizeof(rsp), HAL_MAX_DELAY);
+    }
+}
+
+static VOID uart_thread_entry(ULONG arg)
+{
+    (void)arg;
+    for (;;) {
+        hub_cmd_t cmd;
+        tx_queue_receive(&cmd_queue, &cmd, TX_WAIT_FOREVER);
+        // very basic handler example for UART target
+        hub_rsp_t rsp = {0};
+        if (cmd.target == 0) { // assume 0 == UART
+            HAL_UART_Transmit(&huart5, cmd.data, strlen((char *)cmd.data), HAL_MAX_DELAY);
+            rsp.status = 0; // ok
+        } else {
+            rsp.status = 1; // unknown target
+        }
+        tx_queue_send(&rsp_queue, &rsp, TX_WAIT_FOREVER);
+    }
+}


### PR DESCRIPTION
## Summary
- outline a minimal ThreadX-based I2C hub in `src/i2c_hub.c`
- expose `hub_start()` via new `Inc/i2c_hub.h`
- reference the skeleton from `docs/communication_hub.md` and README

## Testing
- `make clean`
- `make` *(fails: missing toolchain and ninja)*


------
https://chatgpt.com/codex/tasks/task_e_686f7de2db688329a483bf1d52bf7fb3